### PR TITLE
Add bumpversion config file

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,7 @@
+[bumpversion]
+current_version = 1.0.0
+commit = True
+tag = True
+message = Release {new_version}
+
+[bumpversion:file:setup.py]


### PR DESCRIPTION
I'm adding a bumpversion configuration file, so we can avoid problems that we encountered in #128 issue - [bumpversion](https://github.com/peritus/bumpversion) will allow us to bump script's version in an automated way. I'd suggest that we stick to [semantic versioning](https://semver.org/) rule.