### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: xenial
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
     },
     download_url='https://github.com/luk6xff/Packt-Publishing-Free-Learning/archive/v1.2.2.tar.gz',
     classifiers=[
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'


### PR DESCRIPTION
Python 3.4 is no longer maintained (its final release 3.4.10 has been released on 18th March).