### PR TITLE
Fixed to not require anti-captcha config

### DIFF
--- a/src/claimer.py
+++ b/src/claimer.py
@@ -80,6 +80,9 @@ def claim_product(api_client, anticaptcha_key):
         logger.info('You have already claimed Packt Free Learning "{}" offer.'.format(product_data['title']))
         return product_data
 
+    if anticaptcha_key is None:
+        return
+
     logger.info('Started solving ReCAPTCHA on Packt Free Learning website...')
     recaptcha_solution = solve_recaptcha(anticaptcha_key, PACKT_FREE_LEARNING_URL, PACKT_RECAPTCHA_SITE_KEY)
 

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -21,7 +21,8 @@ class ConfigurationModel(object):
     @property
     def anticaptcha_api_key(self):
         """Return AntiCaptcha API key."""
-        return self.configuration.get("ANTICAPTCHA_DATA", 'key')
+        return self.configuration.get("ANTICAPTCHA_DATA", 'key')\
+            if self.configuration.has_option("ANTICAPTCHA_DATA", 'key') else None
 
     @property
     def config_download_data(self):


### PR DESCRIPTION
This also allows downloading today's item using -gd without
anti-captcha if it has already been claimed.

This is an updated PR since #154 and #155 were incorrectly closed as fixed when it was not.