### PR TITLE
Pass ReCAPTCHA solution to login request

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -23,16 +23,15 @@ DEFAULT_PAGINATION_SIZE = 25
 class PacktAPIClient:
     """Packt API client making API requests on script's behalf."""
 
-    def __init__(self, email, password):
-        self.email = email
-        self.password = password
+    def __init__(self, credentials):
         self.session = requests.Session()
+        self.credentials = credentials
         self.fetch_jwt()
 
     def fetch_jwt(self):
         """Fetch user's JWT to be used when making Packt API requests."""
         try:
-            response = requests.post(PACKT_API_LOGIN_URL, json={'username': self.email, 'password': self.password})
+            response = requests.post(PACKT_API_LOGIN_URL, json=self.credentials)
             jwt = response.json().get('data').get('access')
             self.session.headers.update({'authorization': 'Bearer {}'.format(jwt)})
             logger.info('JWT token has been fetched successfully!')

--- a/src/claimer.py
+++ b/src/claimer.py
@@ -10,14 +10,9 @@ from api import (
     PACKT_API_USER_URL,
     PACKT_PRODUCT_SUMMARY_URL
 )
-from utils.anticaptcha import solve_recaptcha
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
-
-
-PACKT_FREE_LEARNING_URL = 'https://www.packtpub.com/packt/offers/free-learning/'
-PACKT_RECAPTCHA_SITE_KEY = '6LeAHSgUAAAAAKsn5jo6RUSTLVxGNYyuvUcLMe0_'
 
 
 def get_all_books_data(api_client):
@@ -52,7 +47,7 @@ def get_single_page_books_data(api_client, page):
         logger.error('Couldn\'t fetch page {} of user\'s books data.'.format(page))
 
 
-def claim_product(api_client, anticaptcha_key):
+def claim_product(api_client, recaptcha_solution):
     """Grab Packt Free Learning ebook."""
     logger.info("Start grabbing ebook...")
 
@@ -79,9 +74,6 @@ def claim_product(api_client, anticaptcha_key):
     if any(product_id == book['id'] for book in get_all_books_data(api_client)):
         logger.info('You have already claimed Packt Free Learning "{}" offer.'.format(product_data['title']))
         return product_data
-
-    logger.info('Started solving ReCAPTCHA on Packt Free Learning website...')
-    recaptcha_solution = solve_recaptcha(anticaptcha_key, PACKT_FREE_LEARNING_URL, PACKT_RECAPTCHA_SITE_KEY)
 
     claim_response = api_client.put(
         PACKT_API_FREE_LEARNING_CLAIM_URL.format(user_id=user_id, offer_id=offer_id),

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -16,7 +16,10 @@ class ConfigurationModel(object):
     @property
     def packt_login_credentials(self):
         """Return Packt user login credentials."""
-        return self.configuration.get('LOGIN_DATA', 'email'), self.configuration.get('LOGIN_DATA', 'password')
+        return {
+            'username': self.configuration.get('LOGIN_DATA', 'email'),
+            'password': self.configuration.get('LOGIN_DATA', 'password')
+        }
 
     @property
     def anticaptcha_api_key(self):

--- a/src/utils/anticaptcha.py
+++ b/src/utils/anticaptcha.py
@@ -59,6 +59,7 @@ class Anticaptcha(object):
         raise AnticaptchaException('Timeout {} reached '.format(self.timeout))
 
     def solve_recaptcha(self, website_url, website_key):
+        logger.info('Started solving ReCAPTCHA for {} website...'.format(website_url))
         task_id = self.__create_noproxy_task(website_url, website_key)
         logger.info('Waiting for completion of the {} task...'.format(task_id))
         solution = self.__wait_for_task_result(task_id)['solution']['gRecaptchaResponse']


### PR DESCRIPTION
Since today ReCAPTCHA solution is required to fetch JWT, but isn't required to make further requests. This should resolve #169.

You can test it by installing script via `pip install git+https://github.com/luk6xff/Packt-Publishing-Free-Learning.git@recaptcha-on-login` and trying to claim Free Learning offer you haven't already claimed.