### PR TITLE
  Sometimes they are several offers in the offer_response. We just get the last updated one.

### DIFF
--- a/src/claimer.py
+++ b/src/claimer.py
@@ -1,6 +1,7 @@
 import datetime as dt
 from itertools import chain
 from math import ceil
+from operator import itemgetter
 
 from api import (
     DEFAULT_PAGINATION_SIZE,
@@ -68,7 +69,9 @@ def claim_product(api_client, recaptcha_solution):
         logger.info("There is no Free Learning offer right now")
         raise Exception("There is no Free Learning offer right now")
 
-    [offer_data] = offer_response.json().get('data')
+    # Sometimes they are several offers. We just get the last updated one.
+    offer_data = max(offer_response.json().get('data'), key=itemgetter('updatedAt'))
+
     offer_id = offer_data.get('id')
     product_id = offer_data.get('productId')
 


### PR DESCRIPTION
Sometimes they are several offers in the response from Packt website. 

For example, yesterday : 
{
    "count": 2,
    "data": [
        {
            "amountAvailable": null,
            "availableFrom": "2020-05-22T00:00:00.000Z",
            "createdAt": "2020-05-20T09:02:39.679Z",
            "deletedAt": null,
            "details": null,
            "expiresAt": "2020-05-23T00:00:00.000Z",
            "id": "35f3ef1f-e878-4743-b417-df902260eca9",
            "limitedAmount": false,
            "priority": 0,
            "productId": "9781838987862",
            "updatedAt": "2020-05-20T09:02:39.679Z"
        },
        {
            "amountAvailable": null,
            "availableFrom": "2020-05-22T00:00:00.000Z",
            "createdAt": "2020-05-20T09:01:41.269Z",
            "deletedAt": null,
            "details": null,
            "expiresAt": "2020-05-23T00:00:00.000Z",
            "id": "803ca6c5-5daf-453c-80a8-75b49614dbaf",
            "limitedAmount": false,
            "priority": 0,
            "productId": "9781788836210",
            "productId": "9781788836210",
            "updatedAt": "2020-05-20T09:01:41.269Z"
        }
    ]
}
The one to get is the last updated one. This pull has been tested during a few days with success.
